### PR TITLE
Rompe dependencia en ROS2 foxy, por defecto mete la 24 que no es compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 langchain==0.1.12
 huggingface-hub==0.21.4
+packaging==23.2


### PR DESCRIPTION
Resuelve el siguinte error en entornos ya montados modernos que estan con la version 24.

ERROR: langchain-core 0.1.39 has requirement packaging<24.0,>=23.2, but you'll have packaging 24.0 which is incompatible.   