### PR TITLE
Add minja support

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ def get_curr_temperature(city: str) -> int:
     """Get the current temperature of a city"""
     return randint(20, 30)
 
-chat = ChatLlamaROS(temp=0.6, penalty_last_n=8, use_default_template=True)
+chat = ChatLlamaROS(temp=0.6, penalty_last_n=8, template_method="jinja")
 
 messages = [
     HumanMessage(
@@ -886,7 +886,7 @@ def get_curr_temperature(city: str) -> int:
     """Get the current temperature of a city"""
     return randint(20, 30)
 
-chat = ChatLlamaROS(temp=0.0, use_default_template=True)
+chat = ChatLlamaROS(temp=0.0, template_method="jinja")
 
 agent_executor = create_react_agent(
     self.chat, [get_inhabitants, get_curr_temperature]

--- a/llama_cpp_vendor/CMakeLists.txt
+++ b/llama_cpp_vendor/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ament_cmake REQUIRED)
 FetchContent_Declare(
   llama
   GIT_REPOSITORY https://github.com/ggerganov/llama.cpp.git
-  GIT_TAG        b4518
+  GIT_TAG        b4539
 )
 
 option(LLAMA_BUILD_COMMON "llama: build common utils library" ON)

--- a/llama_demos/llama_demos/chatllama_demo_node.py
+++ b/llama_demos/llama_demos/chatllama_demo_node.py
@@ -52,11 +52,7 @@ class ChatLlamaDemoNode(Node):
 
     def send_prompt(self) -> None:
 
-        self.chat = ChatLlamaROS(
-            temp=0.2,
-            penalty_last_n=8,
-            template_method="jinja"
-        )
+        self.chat = ChatLlamaROS(temp=0.2, penalty_last_n=8, template_method="jinja")
 
         self.prompt = ChatPromptTemplate.from_messages(
             [

--- a/llama_demos/llama_demos/chatllama_demo_node.py
+++ b/llama_demos/llama_demos/chatllama_demo_node.py
@@ -55,7 +55,7 @@ class ChatLlamaDemoNode(Node):
         self.chat = ChatLlamaROS(
             temp=0.2,
             penalty_last_n=8,
-            use_gguf_template=False,
+            template_method="jinja"
         )
 
         self.prompt = ChatPromptTemplate.from_messages(

--- a/llama_demos/llama_demos/chatllama_langgraph_demo_node.py
+++ b/llama_demos/llama_demos/chatllama_langgraph_demo_node.py
@@ -53,7 +53,7 @@ class ChatLlamaLanggraphDemoNode(Node):
     def __init__(self) -> None:
         super().__init__("chatllama_langgraph_demo_node")
 
-        self.chat = ChatLlamaROS(temp=0.0, use_default_template=True)
+        self.chat = ChatLlamaROS(temp=0.0, template_method="jinja")
         self.agent_executor = create_react_agent(
             self.chat, [get_inhabitants, get_curr_temperature]
         )

--- a/llama_demos/llama_demos/chatllama_tools_demo_node.py
+++ b/llama_demos/llama_demos/chatllama_tools_demo_node.py
@@ -57,7 +57,7 @@ class ChatLlamaToolsDemoNode(Node):
         self.eval_time = -1
 
     def send_prompt(self) -> None:
-        self.chat = ChatLlamaROS(temp=0.0, use_default_template=True)
+        self.chat = ChatLlamaROS(temp=0.0, template_method="jinja")
 
         messages = [
             HumanMessage(

--- a/llama_msgs/srv/FormatChatMessages.srv
+++ b/llama_msgs/srv/FormatChatMessages.srv
@@ -1,10 +1,6 @@
-int8 USE_MINJA=1
-int8 USE_JINJA=2
-int8 USE_LLAMA=3
-
 Message[] messages                   # List of chat messages
 bool add_ass              true       # Add assistant prompt
 bool use_tools            false      
-int8 template_method      1          # Method to build the prompt
+bool use_minja_template   false
 ---
 string formatted_prompt             # Prompt formatted by the model

--- a/llama_msgs/srv/FormatChatMessages.srv
+++ b/llama_msgs/srv/FormatChatMessages.srv
@@ -1,7 +1,10 @@
+int8 USE_MINJA=1
+int8 USE_JINJA=2
+int8 USE_LLAMA=3
+
 Message[] messages                   # List of chat messages
 bool add_ass              true       # Add assistant prompt
-bool use_jinja            false      # Use metadata prompt to generate prompt
 bool use_tools            false      
-bool use_default_template false
+int8 template_method      1          # Method to build the prompt
 ---
 string formatted_prompt             # Prompt formatted by the model

--- a/llama_msgs/srv/FormatChatMessages.srv
+++ b/llama_msgs/srv/FormatChatMessages.srv
@@ -1,4 +1,5 @@
 Message[] messages                  # List of chat messages
 bool add_ass             true       # Add assistant prompt
+bool use_jinja           false      # Use metadata prompt to generate prompt
 ---
 string formatted_prompt             # Prompt formatted by the model

--- a/llama_msgs/srv/FormatChatMessages.srv
+++ b/llama_msgs/srv/FormatChatMessages.srv
@@ -1,5 +1,7 @@
-Message[] messages                  # List of chat messages
-bool add_ass             true       # Add assistant prompt
-bool use_jinja           false      # Use metadata prompt to generate prompt
+Message[] messages                   # List of chat messages
+bool add_ass              true       # Add assistant prompt
+bool use_jinja            false      # Use metadata prompt to generate prompt
+bool use_tools            false      
+bool use_default_template false
 ---
 string formatted_prompt             # Prompt formatted by the model

--- a/llama_msgs/srv/FormatChatMessages.srv
+++ b/llama_msgs/srv/FormatChatMessages.srv
@@ -1,6 +1,6 @@
 Message[] messages                   # List of chat messages
 bool add_ass              true       # Add assistant prompt
 bool use_tools            false      
-bool use_minja_template   false
+bool use_minja            false
 ---
 string formatted_prompt             # Prompt formatted by the model

--- a/llama_ros/include/llama_ros/llama.hpp
+++ b/llama_ros/include/llama_ros/llama.hpp
@@ -181,7 +181,7 @@ public:
   void cancel();
 
   std::string format_chat_prompt(std::vector<common_chat_msg> chat_msgs,
-                                 bool add_ass, bool use_jinja, bool use_tools);
+                                 bool add_ass, bool use_minja, bool use_tools);
   std::vector<struct LoRA> list_loras();
   void update_loras(std::vector<struct LoRA> loras);
 

--- a/llama_ros/include/llama_ros/llama.hpp
+++ b/llama_ros/include/llama_ros/llama.hpp
@@ -180,8 +180,8 @@ public:
   virtual void reset();
   void cancel();
 
-  std::string format_chat_prompt(std::vector<llama_chat_message> chat_msgs,
-                                 bool add_ass, bool use_jinja);
+  std::string format_chat_prompt(std::vector<common_chat_msg> chat_msgs,
+                                 bool add_ass, bool use_jinja, bool use_tools);
   std::vector<struct LoRA> list_loras();
   void update_loras(std::vector<struct LoRA> loras);
 

--- a/llama_ros/include/llama_ros/llama.hpp
+++ b/llama_ros/include/llama_ros/llama.hpp
@@ -180,8 +180,8 @@ public:
   virtual void reset();
   void cancel();
 
-  std::string format_chat_prompt(std::vector<struct common_chat_msg> chat_msgs,
-                                 bool add_ass);
+  std::string format_chat_prompt(std::vector<llama_chat_message> chat_msgs,
+                                 bool add_ass, bool use_jinja);
   std::vector<struct LoRA> list_loras();
   void update_loras(std::vector<struct LoRA> loras);
 

--- a/llama_ros/llama_ros/langchain/chat_llama_ros.py
+++ b/llama_ros/llama_ros/langchain/chat_llama_ros.py
@@ -105,6 +105,7 @@ USE_JINJA = 0
 USE_MINJA = 1
 USE_LLAMA = 2
 
+
 class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
     """
     ChatLlamaROS is a class that extends BaseChatModel and LlamaROSCommon to provide

--- a/llama_ros/llama_ros/langchain/chat_llama_ros.py
+++ b/llama_ros/llama_ros/langchain/chat_llama_ros.py
@@ -152,7 +152,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
                 for message in messages
             ]
             return self.llama_client.format_chat_prompt(
-                FormatChatMessages.Request(messages=ros_messages)
+                FormatChatMessages.Request(messages=ros_messages, use_jinja=True)
             ).formatted_prompt
 
     def _convert_content(

--- a/llama_ros/llama_ros/langchain/chat_llama_ros.py
+++ b/llama_ros/llama_ros/langchain/chat_llama_ros.py
@@ -113,6 +113,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             - "minja": Uses Minja templates to format the prompt.
             - "llama": Uses Llama-specific templates to format the prompt.
     """
+
     template_method: str = FormatChatMessages.Request.USE_JINJA
 
     jinja_env: ImmutableSandboxedEnvironment = ImmutableSandboxedEnvironment(
@@ -131,7 +132,6 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             "llama": FormatChatMessages.Request.USE_LLAMA,
         }[v["template_method"]]
 
-        
         if v["template_value"] not in [
             FormatChatMessages.Request.USE_MINJA,
             FormatChatMessages.Request.USE_JINJA,
@@ -164,7 +164,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             for message in messages
         ]
 
-        if self.template_value == FormatChatMessages.Request.USE_JINJA:            
+        if self.template_value == FormatChatMessages.Request.USE_JINJA:
             bos_token = self.llama_client.detokenize(
                 Detokenize.Request(tokens=[self.model_metadata.tokenizer.bos_token_id])
             ).text

--- a/llama_ros/llama_ros/langchain/chat_llama_ros.py
+++ b/llama_ros/llama_ros/langchain/chat_llama_ros.py
@@ -101,9 +101,9 @@ DEFAULT_TEMPLATE = """{% if tools_grammar %}
 {% endif %}
 """
 
-USE_JINJA = 0
-USE_MINJA = 1
-USE_LLAMA = 2
+USE_JINJA_TEMPLATE = 0
+USE_MINJA_TEMPLATE = 1
+USE_LLAMA_TEMPLATE = 2
 
 
 class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
@@ -118,7 +118,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             - "llama": Uses Llama-specific templates to format the prompt.
     """
 
-    template_method: str = USE_JINJA
+    template_method: str = USE_JINJA_TEMPLATE
 
     jinja_env: ImmutableSandboxedEnvironment = ImmutableSandboxedEnvironment(
         loader=jinja2.BaseLoader(),
@@ -126,20 +126,20 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
         lstrip_blocks=True,
     )
 
-    template_value: int = USE_MINJA
+    template_value: int = USE_MINJA_TEMPLATE
 
     @model_validator(mode="before")
     def validate_template_method(cls, v):
         v["template_value"] = {
-            "minja": USE_MINJA,
-            "jinja": USE_JINJA,
-            "llama": USE_LLAMA,
+            "minja": USE_MINJA_TEMPLATE,
+            "jinja": USE_JINJA_TEMPLATE,
+            "llama": USE_LLAMA_TEMPLATE,
         }[v["template_method"]]
 
         if v["template_value"] not in [
-            USE_MINJA,
-            USE_JINJA,
-            USE_LLAMA,
+            USE_MINJA_TEMPLATE,
+            USE_JINJA_TEMPLATE,
+            USE_LLAMA_TEMPLATE,
         ]:
             raise ValueError(
                 f"template_method must be one of 'jinja', 'minja', or 'llama'. Received: {v}"
@@ -168,7 +168,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             for message in messages
         ]
 
-        if self.template_value == USE_JINJA:
+        if self.template_value == USE_JINJA_TEMPLATE:
             bos_token = self.llama_client.detokenize(
                 Detokenize.Request(tokens=[self.model_metadata.tokenizer.bos_token_id])
             ).text
@@ -184,7 +184,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             return self.llama_client.format_chat_prompt(
                 FormatChatMessages.Request(
                     messages=ros_messages,
-                    use_minja_template=USE_MINJA == self.template_value,
+                    use_minja_template=USE_MINJA_TEMPLATE == self.template_value,
                     use_tools=use_tools,
                 )
             ).formatted_prompt

--- a/llama_ros/llama_ros/langchain/chat_llama_ros.py
+++ b/llama_ros/llama_ros/langchain/chat_llama_ros.py
@@ -114,22 +114,22 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             - "llama": Uses Llama-specific templates to format the prompt.
     """
     template_method: str = FormatChatMessages.Request.USE_JINJA
-    
+
     jinja_env: ImmutableSandboxedEnvironment = ImmutableSandboxedEnvironment(
         loader=jinja2.BaseLoader(),
         trim_blocks=True,
         lstrip_blocks=True,
     )
-    
+
     template_value: int = FormatChatMessages.Request.USE_MINJA
 
     @model_validator(mode="before")
     def validate_template_method(cls, v):
-        v['template_value'] = {
-            'minja': FormatChatMessages.Request.USE_MINJA,
-            'jinja': FormatChatMessages.Request.USE_JINJA,
-            'llama': FormatChatMessages.Request.USE_LLAMA,
-        }[v['template_method']]
+        v["template_value"] = {
+            "minja": FormatChatMessages.Request.USE_MINJA,
+            "jinja": FormatChatMessages.Request.USE_JINJA,
+            "llama": FormatChatMessages.Request.USE_LLAMA,
+        }[v["template_method"]]
 
         
         if v["template_value"] not in [
@@ -140,7 +140,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             raise ValueError(
                 f"template_method must be one of 'jinja', 'minja', or 'llama'. Received: {v}"
             )
-        
+
         return v
 
     @property
@@ -155,7 +155,7 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
         tools: List[BaseTool] = kwargs.get("tools", None)
         use_tools = tools is not None
         formatted_tools = []
-        
+
         if use_tools:
             formatted_tools = [f"- {tool.name}: {tool.description}" for tool in tools]
 
@@ -163,12 +163,12 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             Message(content=message["content"], role=message["role"])
             for message in messages
         ]
-        
+
         if self.template_value == FormatChatMessages.Request.USE_JINJA:            
             bos_token = self.llama_client.detokenize(
                 Detokenize.Request(tokens=[self.model_metadata.tokenizer.bos_token_id])
             ).text
-            
+
             jinja_tmpl = self.jinja_env.from_string(DEFAULT_TEMPLATE)
             return jinja_tmpl.render(
                 messages=messages,
@@ -178,7 +178,11 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             )
         else:
             return self.llama_client.format_chat_prompt(
-                FormatChatMessages.Request(messages=ros_messages, template_method=self.template_value, use_tools=use_tools)
+                FormatChatMessages.Request(
+                    messages=ros_messages,
+                    template_method=self.template_value,
+                    use_tools=use_tools,
+                )
             ).formatted_prompt
 
     def _convert_content(

--- a/llama_ros/src/llama_ros/llama.cpp
+++ b/llama_ros/src/llama_ros/llama.cpp
@@ -563,9 +563,23 @@ Llama::rank_documents(const std::string &query,
 *****************************
 */
 std::string
-Llama::format_chat_prompt(std::vector<struct common_chat_msg> chat_msgs,
-                          bool add_ass) {
-  return common_chat_apply_template(this->get_model(), "", chat_msgs, add_ass);
+Llama::format_chat_prompt(std::vector<llama_chat_message> chat_msgs,
+                          bool add_ass, bool use_jinja) {
+  const char * tmpl = llama_model_chat_template(this->get_model(), /* name */ nullptr);
+  if (!use_jinja) {
+    std::vector<char> formatted(this->get_n_ctx());
+
+    int new_len = llama_chat_apply_template(tmpl, chat_msgs.data(), chat_msgs.size(), true, formatted.data(), formatted.size());
+    formatted.resize(new_len);
+    new_len = llama_chat_apply_template(tmpl, chat_msgs.data(), chat_msgs.size(), true, formatted.data(), formatted.size());
+
+    std::cout << std::string(formatted.data()) << std::endl;
+
+    return std::string(formatted.data());
+  } else {
+    auto chat_templates = common_chat_templates_from_model(this->get_model(), "");
+  }
+  return std::string("");
 }
 
 /*

--- a/llama_ros/src/llama_ros/llama.cpp
+++ b/llama_ros/src/llama_ros/llama.cpp
@@ -26,9 +26,9 @@
 #include <memory>
 #include <thread>
 
+#include "chat-template.hpp"
 #include "common.h"
 #include "sampling.h"
-#include "chat-template.hpp"
 
 #include "llama_ros/llama.hpp"
 #include "llama_utils/logs.hpp"
@@ -563,20 +563,21 @@ Llama::rank_documents(const std::string &query,
 *    FORMAT CHAT SERVICE    *
 *****************************
 */
-std::string
-Llama::format_chat_prompt(std::vector<common_chat_msg> chat_msgs,
-                          bool add_ass, bool use_minja, bool use_tools) {
+std::string Llama::format_chat_prompt(std::vector<common_chat_msg> chat_msgs,
+                                      bool add_ass, bool use_minja,
+                                      bool use_tools) {
   auto chat_templates = common_chat_templates_from_model(this->get_model(), "");
-  
+
   const common_chat_template *selected_template;
 
   if (use_tools) {
-      selected_template = chat_templates.template_tool_use.get();
+    selected_template = chat_templates.template_tool_use.get();
   } else {
-      selected_template = chat_templates.template_default.get();
+    selected_template = chat_templates.template_default.get();
   }
 
-  return common_chat_apply_template(*selected_template, chat_msgs, add_ass, use_minja);
+  return common_chat_apply_template(*selected_template, chat_msgs, add_ass,
+                                    use_minja);
 }
 
 /*

--- a/llama_ros/src/llama_ros/llama.cpp
+++ b/llama_ros/src/llama_ros/llama.cpp
@@ -565,7 +565,7 @@ Llama::rank_documents(const std::string &query,
 */
 std::string
 Llama::format_chat_prompt(std::vector<common_chat_msg> chat_msgs,
-                          bool add_ass, bool use_jinja, bool use_tools) {
+                          bool add_ass, bool use_minja, bool use_tools) {
   auto chat_templates = common_chat_templates_from_model(this->get_model(), "");
   
   const common_chat_template *selected_template;
@@ -576,7 +576,7 @@ Llama::format_chat_prompt(std::vector<common_chat_msg> chat_msgs,
       selected_template = chat_templates.template_default.get();
   }
 
-  return common_chat_apply_template(*selected_template, chat_msgs, add_ass, use_jinja);
+  return common_chat_apply_template(*selected_template, chat_msgs, add_ass, use_minja);
 }
 
 /*

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -392,7 +392,8 @@ void LlamaNode::format_chat_service_callback(
   }
 
   std::string formatted_chat = this->llama->format_chat_prompt(
-      converted_messages, request->add_ass, request->use_minja_template, request->use_tools);
+      converted_messages, request->add_ass, request->use_minja_template,
+      request->use_tools);
 
   response->formatted_prompt = formatted_chat;
 }

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -391,10 +391,11 @@ void LlamaNode::format_chat_service_callback(
     converted_messages.push_back(aux);
   }
 
-  bool use_minja = request->template_method == llama_msgs::srv::FormatChatMessages::Request::USE_MINJA;
+  bool use_minja = request->template_method ==
+                   llama_msgs::srv::FormatChatMessages::Request::USE_MINJA;
 
-  std::string formatted_chat =
-      this->llama->format_chat_prompt(converted_messages, request->add_ass, use_minja, request->use_tools);
+  std::string formatted_chat = this->llama->format_chat_prompt(
+      converted_messages, request->add_ass, use_minja, request->use_tools);
 
   response->formatted_prompt = formatted_chat;
 }

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -391,9 +391,9 @@ void LlamaNode::format_chat_service_callback(
     converted_messages.push_back(aux);
   }
 
-  std::string formatted_chat = this->llama->format_chat_prompt(
-      converted_messages, request->add_ass, request->use_minja_template,
-      request->use_tools);
+  std::string formatted_chat =
+      this->llama->format_chat_prompt(converted_messages, request->add_ass,
+                                      request->use_minja, request->use_tools);
 
   response->formatted_prompt = formatted_chat;
 }

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -382,9 +382,9 @@ void LlamaNode::format_chat_service_callback(
     const std::shared_ptr<llama_msgs::srv::FormatChatMessages::Request> request,
     std::shared_ptr<llama_msgs::srv::FormatChatMessages::Response> response) {
 
-  std::vector<struct common_chat_msg> converted_messages;
+  std::vector<llama_chat_message> converted_messages;
   for (auto message : request->messages) {
-    struct common_chat_msg aux;
+    llama_chat_message aux;
     aux.role = message.role.c_str();
     aux.content = message.content.c_str();
 
@@ -392,7 +392,7 @@ void LlamaNode::format_chat_service_callback(
   }
 
   std::string formatted_chat =
-      this->llama->format_chat_prompt(converted_messages, request->add_ass);
+      this->llama->format_chat_prompt(converted_messages, request->add_ass, request->use_jinja);
 
   response->formatted_prompt = formatted_chat;
 }

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -382,17 +382,17 @@ void LlamaNode::format_chat_service_callback(
     const std::shared_ptr<llama_msgs::srv::FormatChatMessages::Request> request,
     std::shared_ptr<llama_msgs::srv::FormatChatMessages::Response> response) {
 
-  std::vector<llama_chat_message> converted_messages;
+  std::vector<common_chat_msg> converted_messages;
   for (auto message : request->messages) {
-    llama_chat_message aux;
-    aux.role = message.role.c_str();
-    aux.content = message.content.c_str();
+    common_chat_msg aux;
+    aux.role = message.role;
+    aux.content = message.content;
 
     converted_messages.push_back(aux);
   }
 
   std::string formatted_chat =
-      this->llama->format_chat_prompt(converted_messages, request->add_ass, request->use_jinja);
+      this->llama->format_chat_prompt(converted_messages, request->add_ass, request->use_jinja, request->use_tools);
 
   response->formatted_prompt = formatted_chat;
 }

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -391,8 +391,10 @@ void LlamaNode::format_chat_service_callback(
     converted_messages.push_back(aux);
   }
 
+  bool use_minja = request->template_method == llama_msgs::srv::FormatChatMessages::Request::USE_MINJA;
+
   std::string formatted_chat =
-      this->llama->format_chat_prompt(converted_messages, request->add_ass, request->use_jinja, request->use_tools);
+      this->llama->format_chat_prompt(converted_messages, request->add_ass, use_minja, request->use_tools);
 
   response->formatted_prompt = formatted_chat;
 }

--- a/llama_ros/src/llama_ros/llama_node.cpp
+++ b/llama_ros/src/llama_ros/llama_node.cpp
@@ -391,11 +391,8 @@ void LlamaNode::format_chat_service_callback(
     converted_messages.push_back(aux);
   }
 
-  bool use_minja = request->template_method ==
-                   llama_msgs::srv::FormatChatMessages::Request::USE_MINJA;
-
   std::string formatted_chat = this->llama->format_chat_prompt(
-      converted_messages, request->add_ass, use_minja, request->use_tools);
+      converted_messages, request->add_ass, request->use_minja_template, request->use_tools);
 
   response->formatted_prompt = formatted_chat;
 }


### PR DESCRIPTION
Support for the Jinja template engine for C++: minja, included in the latest version of llama.cpp.
To use this tool, set the template_method in chat_llama_ros to "minja". It also supports "jinja" to use a default template and "llama".