### PR TITLE
Shutdown lifecycle bug fix in llava

### DIFF
--- a/llama_ros/src/llava_ros/llava_node.cpp
+++ b/llama_ros/src/llava_ros/llava_node.cpp
@@ -40,6 +40,7 @@ using namespace llava_ros;
 LlavaNode::LlavaNode() : llama_ros::LlamaNode() {}
 
 void LlavaNode::create_llama() {
+  this->shutting_down_.store(false);
   this->llama =
       std::make_unique<Llava>(this->params.params, this->params.system_prompt);
 


### PR DESCRIPTION
Using lifecycles, if a node is reactivated, the shutting_down_ condition is not reset, so all petitions are cancelled by the goal_handler