### PR TITLE
feat(llama): reuse KV-cached prefix between consecutive requests

### DIFF
--- a/llama_ros/include/llama_ros/server_slot.hpp
+++ b/llama_ros/include/llama_ros/server_slot.hpp
@@ -203,6 +203,25 @@ public:
   /// @brief Map from position to media chunk for multimodal processing.
   std::unordered_map<llama_pos, mtmd::input_chunk_ptr> map_pos_to_media;
 
+  /// @brief Tokens currently materialized in this slot's KV cache.
+  /// Preserved across reset() to enable prefix reuse between requests.
+  /// Empty when the cache is invalid (cold slot, post-shift, post-error).
+  std::vector<llama_token> kv_cached_tokens;
+
+  /**
+   * @brief Length of the longest prefix of @p incoming that matches what is
+   * currently materialized in this slot's KV. Returns 0 when no reuse is
+   * possible (cache empty, multimodal placeholders present). Reserves one
+   * trailing token for re-evaluation so generation has fresh logits.
+   */
+  size_t find_reusable_prefix(const std::vector<llama_token> &incoming) const;
+
+  /**
+   * @brief Drop the cached-prefix bookkeeping. Next request will fully
+   * re-process its prompt. Use after context shift or decode error.
+   */
+  void invalidate_kv_cache();
+
   /**
    * @brief Resets the slot to its initial state.
    */

--- a/llama_ros/src/llama_ros/llama.cpp
+++ b/llama_ros/src/llama_ros/llama.cpp
@@ -1404,9 +1404,8 @@ void Llama::run_loop() {
           // when the prompt diverges or caching is disabled for this slot.
           const bool caching_allowed =
               this->params.cache_prompt && !this->is_speculative();
-          const size_t reused = caching_allowed
-                                    ? slot.find_reusable_prefix(prompt_tokens)
-                                    : 0;
+          const size_t reused =
+              caching_allowed ? slot.find_reusable_prefix(prompt_tokens) : 0;
           auto *mem = llama_get_memory(this->ctx);
 
           if (reused > 0) {

--- a/llama_ros/src/llama_ros/llama.cpp
+++ b/llama_ros/src/llama_ros/llama.cpp
@@ -1269,6 +1269,8 @@ void Llama::run_loop() {
                                  n_keep + n_discard, slot.n_past, -n_discard);
 
             slot.n_past -= n_discard;
+            // Sliding window shifted KV positions: drop the cached prefix.
+            slot.invalidate_kv_cache();
           }
 
         } else {
@@ -1293,6 +1295,8 @@ void Llama::run_loop() {
                                  slot.n_past + ib * bd, dd);
 
             slot.n_past -= bd;
+            // Self-Extend reshuffled KV positions: drop the cached prefix.
+            slot.invalidate_kv_cache();
 
             slot.ga_i += ga_w / ga_n;
           }
@@ -1378,9 +1382,6 @@ void Llama::run_loop() {
         // first-time setup for a new prompt
         if (slot.state == SLOT_STATE_STARTED) {
 
-          // always start from zero KV
-          slot.n_past = 0;
-
           slot.n_prompt_tokens = prompt_tokens.size();
           slot.state = SLOT_STATE_PROCESSING_PROMPT;
 
@@ -1399,8 +1400,27 @@ void Llama::run_loop() {
             continue;
           }
 
-          // wipe any previous KV for this seq
-          llama_memory_seq_rm(llama_get_memory(this->ctx), slot.id, -1, -1);
+          // Reuse the KV-cached prefix when allowed; fall back to a full wipe
+          // when the prompt diverges or caching is disabled for this slot.
+          const bool caching_allowed =
+              this->params.cache_prompt && !this->is_speculative();
+          const size_t reused = caching_allowed
+                                    ? slot.find_reusable_prefix(prompt_tokens)
+                                    : 0;
+          auto *mem = llama_get_memory(this->ctx);
+
+          if (reused > 0) {
+            llama_memory_seq_rm(mem, slot.id, static_cast<llama_pos>(reused),
+                                -1);
+            slot.n_past = static_cast<int32_t>(reused);
+            LLAMA_LOG_INFO("Slot %d: reused %zu/%zu tokens from KV cache",
+                           slot.id, reused, prompt_tokens.size());
+          } else {
+            slot.n_past = 0;
+            llama_memory_seq_rm(mem, slot.id, -1, -1);
+            LLAMA_LOG_INFO("Slot %d: KV cache cold start (0/%zu reused)",
+                           slot.id, prompt_tokens.size());
+          }
 
           // clear idle slots to free up VRAM when a new task starts
           if (this->params.cache_idle_slots) {
@@ -1409,10 +1429,10 @@ void Llama::run_loop() {
                   other.n_past > 0) {
                 LLAMA_LOG_INFO("Clearing idle slot %d (n_past=%d) for new task",
                                other.id, other.n_past);
-                llama_memory_seq_rm(llama_get_memory(this->ctx), other.id, -1,
-                                    -1);
+                llama_memory_seq_rm(mem, other.id, -1, -1);
                 other.n_past = 0;
                 other.prompt_tokens.clear();
+                other.invalidate_kv_cache();
               }
             }
           }
@@ -1480,9 +1500,14 @@ void Llama::run_loop() {
           slot.n_decoded = 0;
           slot.i_batch = this->batch.n_tokens - 1;
 
-          LLAMA_LOG_INFO(
-              "prompt done (no caching), n_past = %d, n_tokens = %d\n",
-              slot.n_past, this->batch.n_tokens);
+          // Only completion tasks benefit from prefix reuse; an embedding or
+          // rerank prompt would mismatch the next request's task type.
+          if (slot.task_type == SERVER_TASK_TYPE_COMPLETION) {
+            slot.kv_cached_tokens = slot.prompt_tokens;
+          }
+
+          LLAMA_LOG_INFO("prompt done, n_past = %d, n_tokens = %d\n",
+                         slot.n_past, this->batch.n_tokens);
         }
 
         if (static_cast<uint32_t>(this->batch.n_tokens) >=
@@ -1535,8 +1560,9 @@ void Llama::run_loop() {
           LLAMA_LOG_ERROR("Decoding error: %s (ret=%d, n_batch=%d, i=%d, "
                           "batch_n_tokens=%d)",
                           err.c_str(), ret, n_tokens, i, this->batch.n_tokens);
-          // Log all active slots so we know who triggered this
-          for (const auto &slot : this->server_slots) {
+          // A decode failure leaves the KV state of every active slot
+          // unknown; drop their prefix caches so the next request re-processes.
+          for (auto &slot : this->server_slots) {
             if (slot.is_processing()) {
               LLAMA_LOG_ERROR(
                   "  Active slot id=%d gid=%lu state=%d task_type=%d "
@@ -1545,6 +1571,7 @@ void Llama::run_loop() {
                   slot.n_past, slot.n_ctx, slot.n_prompt_tokens,
                   slot.n_decoded);
             }
+            slot.invalidate_kv_cache();
           }
           this->cancel();
           break; // abort the decode loop

--- a/llama_ros/src/llama_ros/server_slot.cpp
+++ b/llama_ros/src/llama_ros/server_slot.cpp
@@ -78,7 +78,32 @@ void ServerSlot::reset() {
 
   this->map_pos_to_media.clear();
   this->prompt_tokens.clear();
+  // kv_cached_tokens is intentionally preserved: it tracks the KV state of
+  // this slot's sequence, which survives request boundaries.
 }
+
+size_t ServerSlot::find_reusable_prefix(
+    const std::vector<llama_token> &incoming) const {
+  if (this->kv_cached_tokens.empty() || !this->map_pos_to_media.empty()) {
+    return 0;
+  }
+  const size_t max_check =
+      std::min(this->kv_cached_tokens.size(), incoming.size());
+  size_t i = 0;
+  while (i < max_check && this->kv_cached_tokens[i] == incoming[i] &&
+         incoming[i] != LLAMA_TOKEN_NULL) {
+    i++;
+  }
+  // Reserve one trailing position so the model re-evaluates a token and the
+  // next sampling step has fresh logits. The caller's seq_rm physically
+  // drops that position from the KV.
+  if (i == incoming.size() && i > 0) {
+    i--;
+  }
+  return i;
+}
+
+void ServerSlot::invalidate_kv_cache() { this->kv_cached_tokens.clear(); }
 
 void ServerSlot::release() {
   LLAMA_LOG_INFO("Trying to release slot %d", this->id);


### PR DESCRIPTION
## Summary

Adds KV-cache prefix reuse between consecutive requests on the same slot. Until now the slot KV was wiped on every new request ("always start from zero KV"), so every prompt was re-processed in full.

## Motivation

For tasks with a long static prefix (system prompt, domain, output schema) and a short dynamic suffix (new observations, updated state), the prompt-processing cost dominates inference time. Reusing the KV-cached prefix removes that cost from every request after the first.

## What changed

- `ServerSlot` keeps the tokens currently materialized in its KV sequence across `reset()`.
- New `ServerSlot::find_reusable_prefix()` returns the longest token prefix shared with the incoming prompt.
- New `ServerSlot::invalidate_kv_cache()` drops the bookkeeping after a context shift or decode error.
- `Llama::run_loop()` calls the helpers on each new request and wipes only the divergent suffix via `llama_memory_seq_rm(slot.id, reused, -1)`.
- The existing `cache_prompt` parameter (default `true`) now gates this behaviour. Bypassed when `is_speculative()`, when multimodal placeholders are present in the prompt, or after a shift/error invalidated the positions.

Only completion tasks snapshot their prompt; embedding/rerank prompts are not cached because the next request may be a different task type.

## Benchmark

Raspberry Pi 5 (16 GB), Qwen2.5-3B-Instruct Q4_K_M, n_threads=4, n_ctx=8192, ~3500-token prompt:

| Call                          | Prompt eval | Tokens reused |
|-------------------------------|-------------|---------------|
| 1 (cold)                      | 153.2 s     | 0/3469        |
| 2 (identical prompt)          | 0.41 s      | 3468/3469     |
| 3 (small change at the tail)  | 19.2 s      | 3157/3506     |

## Notes

- Single-slot (`n_parallel=1`) is the only configuration tested. For `n_parallel>1` the patch keeps per-slot caching: correct but does not route requests to the slot with the best prefix match.
- No new parameters introduced. `cache_prompt` was already parsed but unused in the runtime; this is its first consumer.
