### PR TITLE
Pass tool_call_id, required for Mistral-Nemo

### DIFF
--- a/llama_ros/llama_ros/langchain/chat_llama_ros.py
+++ b/llama_ros/llama_ros/langchain/chat_llama_ros.py
@@ -864,6 +864,9 @@ class ChatLlamaROS(BaseChatModel, LlamaROSCommon):
             chat_message = RChatMessage()
             chat_message.role = message["role"]
 
+            if "tool_call_id" in message:
+                chat_message.tool_call_id = message["tool_call_id"]
+                            
             for tool_call in message.get("tool_calls", []):
                 chat_tool_call = ChatToolCall()
                 chat_tool_call.id = tool_call["id"]

--- a/llama_ros/src/llama_utils/chat_utils.cpp
+++ b/llama_ros/src/llama_utils/chat_utils.cpp
@@ -74,7 +74,7 @@ common_chat_templates_inputs llama_utils::parse_chat_completions_goal(
     common_chat_msg msg;
     msg.role = message.role;
     msg.content = message.content;
-    msg.tool_call_id = message.tool_call_id;    
+    msg.tool_call_id = message.tool_call_id;
     std::vector<common_chat_msg_content_part> content_parts;
 
     for (auto content_part : message.content_parts) {

--- a/llama_ros/src/llama_utils/chat_utils.cpp
+++ b/llama_ros/src/llama_utils/chat_utils.cpp
@@ -74,6 +74,7 @@ common_chat_templates_inputs llama_utils::parse_chat_completions_goal(
     common_chat_msg msg;
     msg.role = message.role;
     msg.content = message.content;
+    msg.tool_call_id = message.tool_call_id;    
     std::vector<common_chat_msg_content_part> content_parts;
 
     for (auto content_part : message.content_parts) {


### PR DESCRIPTION
I have tested this only with the model Mistral-Nemo-Instruct-2407-Q4_K_M.gguf. 

Possibly, these patches are not enough. The tool_call_id values generated by the line ```tool_call.id = "call_" + llama_utils::random_string(8);``` in the file ```chat_utils.cpp``` are not 9 alphanumeric characters as required for Mistral-Nemo. I fix that in my application code, because changing this in llama_ros may break interaction with other models (I haven't tested if this is true).